### PR TITLE
Limit test workflow trigger on push to main and bors branches

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,10 @@ name: Test
 
 on:
   push:
+    branches:
+    - main
+    - staging
+    - trying
   pull_request:
 
 jobs:


### PR DESCRIPTION
With bors enabled there's no need to build all branches on push.