### PR TITLE
Add intern crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = [
+  "crates/intern",
   "crates/lexer",
   "crates/syntax"
 ]

--- a/crates/intern/Cargo.toml
+++ b/crates/intern/Cargo.toml
@@ -1,0 +1,9 @@
+[project]
+name = "tydi-intern"
+version = "0.0.0"
+edition = "2018"
+publish = false
+description = "Intern support for Tydi"
+
+[dependencies]
+salsa = "0.16"

--- a/crates/intern/src/lib.rs
+++ b/crates/intern/src/lib.rs
@@ -24,12 +24,19 @@ macro_rules! intern_id {
 
 intern_id!(String, StringId);
 
-/// Super trait for intern traits with intern support for primitive types.
-#[salsa::query_group(InternSupportDatabase)]
-pub trait InternSupport {
-    #[salsa::interned]
-    fn intern_string(&self, string: String) -> StringId;
+mod query {
+    use super::*;
+
+    /// Super trait for intern traits with intern support for primitive types.
+    #[salsa::query_group(InternSupportDatabase)]
+    pub trait InternSupport {
+        #[salsa::interned]
+        fn intern_string(&self, string: String) -> StringId;
+    }
 }
+
+// Export the query group trait and storage struct.
+pub use query::{InternSupport, InternSupportDatabase};
 
 /// Transforms owned data types to referenced data types.
 pub trait IntoRefData {

--- a/crates/intern/src/lib.rs
+++ b/crates/intern/src/lib.rs
@@ -1,0 +1,116 @@
+/// Macro to generate new type wrappers for Salsa's intern ID.
+#[macro_export]
+macro_rules! intern_id {
+    ($item:ident, $id:ident) => {
+        #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+        pub struct $id(salsa::InternId);
+
+        impl std::fmt::Display for $id {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                self.0.fmt(f)
+            }
+        }
+
+        impl salsa::InternKey for $id {
+            fn from_intern_id(id: salsa::InternId) -> Self {
+                Self(id)
+            }
+            fn as_intern_id(&self) -> salsa::InternId {
+                self.0
+            }
+        }
+    };
+}
+
+intern_id!(String, StringId);
+
+/// Super trait for intern traits with intern support for primitive types.
+#[salsa::query_group(InternSupportDatabase)]
+pub trait InternSupport {
+    #[salsa::interned]
+    fn intern_string(&self, string: String) -> StringId;
+}
+
+/// Transforms owned data types to referenced data types.
+pub trait IntoRefData {
+    /// Identifier type used when interning this type.
+    type Id;
+    /// Reference data type for this type. This replaces owned values with
+    /// reference data types to interned values.
+    type RefData;
+
+    /// Interns self in the database and returns an instance of the reference
+    /// data type.
+    fn into_ref_data(self, db: &dyn InternSupport) -> Self::RefData;
+}
+
+// Implement IntoRefData without interning i.e. Self is Id and RefData.
+macro_rules! into_ref_data_self {
+    ($($ident:ident),*) => {
+        $(
+            impl IntoRefData for $ident {
+                type Id = Self;
+                type RefData = Self;
+                fn into_ref_data(self, _db: &dyn InternSupport) -> Self::RefData {
+                    self
+                }
+            }
+        )*
+    };
+}
+
+// These copy types are not interned and stored in reference data types.
+into_ref_data_self!(u8, u16, u32, u64, u128, usize, i8, i16, i32, i64, i128, isize);
+
+impl IntoRefData for String {
+    type Id = StringId;
+    type RefData = StringId;
+    fn into_ref_data(self, db: &dyn InternSupport) -> Self::RefData {
+        // Insert the String in the intern database.
+        db.intern_string(self)
+    }
+}
+
+impl<T> IntoRefData for Vec<T>
+where
+    T: IntoRefData,
+{
+    type Id = <T as IntoRefData>::Id;
+    type RefData = Vec<<T as IntoRefData>::RefData>;
+
+    fn into_ref_data(self, db: &dyn InternSupport) -> Self::RefData {
+        // Return new vec with the reference data types of all the items in the
+        // vec.
+        self.into_iter()
+            .map(|item| item.into_ref_data(db))
+            .collect()
+    }
+}
+
+impl<T> IntoRefData for Option<T>
+where
+    T: IntoRefData,
+{
+    type Id = <T as IntoRefData>::Id;
+    type RefData = Option<<T as IntoRefData>::RefData>;
+
+    fn into_ref_data(self, db: &dyn InternSupport) -> Self::RefData {
+        // Return new option with the reference data type of the inner value of
+        // the Option.
+        self.map(|item| item.into_ref_data(db))
+    }
+}
+
+impl<T> IntoRefData for Box<T>
+where
+    T: IntoRefData,
+{
+    type Id = <T as IntoRefData>::Id;
+    type RefData = Box<<T as IntoRefData>::RefData>;
+
+    fn into_ref_data(self, db: &dyn InternSupport) -> Self::RefData {
+        // Return new box with reference data type of the inner value of the
+        // Box.
+        Box::new((*self).into_ref_data(db))
+    }
+}


### PR DESCRIPTION
Add an intern crate with the following public items:
- `intern_id` macro to generate new type wrappers for Salsa's intern IDs.
- `InternSupport`: a Salsa query group to intern primitives. Other Salsa intern query groups can use this as super trait.
- `IntoRefData` trait to transform owned data into reference data types with an associated type for the interner ID type.

bors r+