### PR TITLE
Add boilerplate for hir and db crates

### DIFF
--- a/crates/db/Cargo.toml
+++ b/crates/db/Cargo.toml
@@ -1,0 +1,11 @@
+[project]
+name = "tydi-db"
+version = "0.0.0"
+edition = "2018"
+publish = false
+description = "Compiler database for Tydi"
+
+[dependencies]
+salsa = "0.16"
+tydi-hir = { path = "../hir" }
+tydi-intern = { path = "../intern" }

--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -1,0 +1,42 @@
+#[salsa::database(tydi_hir::InternHirDatabase, tydi_intern::InternSupportDatabase)]
+#[derive(Default)]
+pub struct Database {
+    storage: salsa::Storage<Database>,
+}
+
+impl salsa::Database for Database {}
+
+#[cfg(test)]
+mod tests {
+    use super::Database;
+    use tydi_hir::{Identifier, InternHir, Package};
+    use tydi_intern::{InternSupport, IntoRefData};
+
+    const IDENT: &str = "test";
+
+    #[test]
+    fn intern_support() {
+        let db = Database::default();
+
+        let id = db.intern_string(IDENT.to_string());
+        assert_eq!(db.lookup_intern_string(id), IDENT.to_string());
+    }
+
+    #[test]
+    fn intern_hir() {
+        let db = Database::default();
+
+        let string_id = db.intern_string(IDENT.to_string());
+        let package_ref_data = Package {
+            identifier: Identifier(String::from(IDENT)),
+        }
+        .into_ref_data(&db);
+
+        let identifier_ref_data = Identifier(String::from(IDENT)).into_ref_data(&db);
+        assert_eq!(package_ref_data.identifier, identifier_ref_data);
+        assert_eq!(identifier_ref_data._0, string_id);
+
+        let package_id = db.intern_package(package_ref_data.clone());
+        assert_eq!(db.lookup_intern_package(package_id), package_ref_data);
+    }
+}

--- a/crates/hir/Cargo.toml
+++ b/crates/hir/Cargo.toml
@@ -1,0 +1,11 @@
+[project]
+name = "tydi-hir"
+version = "0.0.0"
+edition = "2018"
+publish = false
+description = "High-level intermediate representation of Tydi"
+
+[dependencies]
+salsa = "0.16"
+tydi-macros = { path = "../macros" }
+tydi-intern = { path = "../intern" }

--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -1,0 +1,10 @@
+#[tydi_macros::ir]
+mod hir {
+    pub struct Identifier(pub String);
+
+    pub struct Package {
+        pub identifier: Identifier,
+    }
+}
+
+pub use hir::*;

--- a/crates/macros/src/ir.rs
+++ b/crates/macros/src/ir.rs
@@ -175,6 +175,7 @@ pub(super) fn gen(item: TokenStream) -> TokenStream {
                 #tokens
             }
             pub use gen::#intern_trait;
+            pub use gen::#intern_storage;
             #(
                 pub use gen::#intern_id;
                 pub use gen::#intern_ref_data;


### PR DESCRIPTION
This adds boilerplate for the `hir` and `db` crates. They are added now to validate that the ir` attribute proc macro is useful.

bors r+