### PR TITLE
Add enum support to ir attr proc macro

### DIFF
--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -34,7 +34,7 @@ mod tests {
 
         let identifier_ref_data = Identifier(String::from(IDENT)).into_ref_data(&db);
         assert_eq!(package_ref_data.identifier, identifier_ref_data);
-        assert_eq!(identifier_ref_data._0, string_id);
+        assert_eq!(identifier_ref_data.0, string_id);
 
         let package_id = db.intern_package(package_ref_data.clone());
         assert_eq!(db.lookup_intern_package(package_id), package_ref_data);

--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -9,7 +9,7 @@ impl salsa::Database for Database {}
 #[cfg(test)]
 mod tests {
     use super::Database;
-    use tydi_hir::{Identifier, InternHir, Package};
+    use tydi_hir::{Identifier, InternHir, Package, Type, TypeRefData};
     use tydi_intern::{InternSupport, IntoRefData};
 
     const IDENT: &str = "test";
@@ -38,5 +38,16 @@ mod tests {
 
         let package_id = db.intern_package(package_ref_data.clone());
         assert_eq!(db.lookup_intern_package(package_id), package_ref_data);
+
+        let type_ref_data = Type::Path {
+            segments: vec![Identifier(String::from(IDENT))],
+        }
+        .into_ref_data(&db);
+        assert_eq!(
+            type_ref_data,
+            TypeRefData::Path {
+                segments: vec![identifier_ref_data],
+            }
+        );
     }
 }

--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -5,6 +5,12 @@ mod hir {
     pub struct Package {
         pub identifier: Identifier,
     }
+
+    pub enum Type {
+        Bits(usize),
+        Stream,
+        Path { segments: Vec<Identifier> },
+    }
 }
 
 pub use hir::*;

--- a/crates/macros/src/ir.rs
+++ b/crates/macros/src/ir.rs
@@ -4,85 +4,141 @@ use proc_macro2::TokenStream as TokenStream2;
 use quote::{format_ident, quote};
 use syn::{
     parse, punctuated::Punctuated, token::Comma, Field, Fields, FieldsNamed, FieldsUnnamed, Ident,
-    Index, Item, ItemMod, ItemStruct, Type,
+    Index, Item, ItemEnum, ItemMod, ItemStruct, Type, Variant,
 };
 
-// Capture the required information for code generation.
-enum InternItem {
-    Struct { ident: Ident, fields: Fields },
-    // todo(mb)
-    // Enum {},
+fn item_ident(item: &Item) -> &Ident {
+    match item {
+        Item::Struct(ItemStruct { ident, .. }) | Item::Enum(ItemEnum { ident, .. }) => ident,
+        _ => unimplemented!(),
+    }
 }
 
-impl InternItem {
-    /// Returns ident from struct or enum.
-    fn ident(&self) -> &Ident {
-        match self {
-            InternItem::Struct { ident, .. } => ident,
-            // _ => todo!(),
-        }
-    }
+fn intern_id_ident(ident: &Ident) -> Ident {
+    format_ident!("{}Id", ident)
+}
 
-    /// Returns ident for ID struct.
-    fn intern_id(&self) -> Ident {
-        format_ident!("{}Id", self.ident())
-    }
+fn ref_data_ident(ident: &Ident) -> Ident {
+    format_ident!("{}RefData", ident)
+}
 
-    /// Returns ident for RefData struct.
-    fn ref_data(&self) -> Ident {
-        format_ident!("{}RefData", self.ident())
-    }
+fn intern_fn_ident(ident: &Ident) -> Ident {
+    format_ident!("intern_{}", ident.to_string().to_snake_case())
+}
 
-    /// Returns ident for intern trait fn.
-    fn intern_fn(&self) -> Ident {
-        format_ident!("intern_{}", self.ident().to_string().to_snake_case())
-    }
+fn fields_iter(fields: &Fields) -> impl Iterator<Item = Field> {
+    (match fields.clone() {
+        Fields::Unit => Punctuated::<Field, Comma>::new(),
+        Fields::Named(FieldsNamed { named: fields, .. })
+        | Fields::Unnamed(FieldsUnnamed {
+            unnamed: fields, ..
+        }) => fields,
+    })
+    .into_iter()
+}
 
-    /// Return an iterator over the fields of the struct.
-    fn fields(&self) -> impl Iterator<Item = Field> {
-        match self {
-            InternItem::Struct { fields, .. } => match fields.clone() {
-                Fields::Unit => Punctuated::<Field, Comma>::new().into_iter(),
-                Fields::Named(FieldsNamed { named: fields, .. })
-                | Fields::Unnamed(FieldsUnnamed {
-                    unnamed: fields, ..
-                }) => fields.into_iter(),
-            },
-            // _ => todo!(),
-        }
-    }
+fn fields_ident_iter(fields: &Fields) -> impl Iterator<Item = Ident> {
+    fields_iter(fields)
+        .enumerate()
+        .map(|(idx, Field { ident, .. })| ident.unwrap_or_else(|| format_ident!("_{}", idx)))
+}
 
-    /// Return an iterator over the idents of the fields of the struct.
-    fn field_ident(&self) -> impl Iterator<Item = Ident> {
-        self.fields()
-            .enumerate()
-            .map(|(idx, Field { ident, .. })| ident.unwrap_or_else(|| format_ident!("_{}", idx)))
-    }
+fn fields_index_iter(fields: &Fields) -> impl Iterator<Item = TokenStream2> {
+    fields_iter(fields)
+        .enumerate()
+        .map(|(idx, Field { ident, .. })| match ident {
+            Some(ident) => quote!(#ident),
+            None => {
+                let idx = Index::from(idx);
+                quote!(#idx)
+            }
+        })
+}
 
-    /// Returns an iterator over idents that can be used to index fields.
-    fn field_index(&self) -> impl Iterator<Item = TokenStream2> {
-        self.fields()
-            .enumerate()
-            .map(|(idx, Field { ident, .. })| match ident {
-                Some(ident) => quote!(#ident),
-                None => {
-                    let idx = Index::from(idx);
-                    quote!(#idx)
+fn fields_types_iter(fields: &Fields) -> impl Iterator<Item = Type> {
+    fields_iter(fields).map(|Field { ty, .. }| ty)
+}
+
+type Variants = Punctuated<Variant, Comma>;
+
+fn variant_ref_data_iter(variants: &Variants) -> impl Iterator<Item = TokenStream2> + '_ {
+    variants
+        .into_iter()
+        .map(|Variant { ident, fields, .. }| match fields {
+            Fields::Unnamed(FieldsUnnamed { unnamed, .. }) => {
+                let ty = unnamed.into_iter().map(|Field { ty, .. }| ty);
+                quote! {
+                    #ident(
+                        #(
+                            #ty,
+                        )*
+                    )
                 }
-            })
-    }
+            }
+            Fields::Unit => quote!(#ident),
+            Fields::Named(FieldsNamed { named, .. }) => {
+                let field = named
+                    .iter()
+                    .map(|Field { ident, .. }| ident.as_ref().unwrap());
+                let ty = named.iter().map(|Field { ty, .. }| ty);
+                quote!(
+                    #ident {
+                        #(
+                            #field: <#ty as ::tydi_intern::IntoRefData>::RefData,
+                        )*
+                    }
+                )
+            }
+        })
+}
 
-    /// Returns an iterator over the types of the fields of the struct.
-    fn field_types(&self) -> impl Iterator<Item = Type> {
-        self.fields().map(|Field { ty, .. }| ty)
-    }
+fn variant_into_ref_data_iter(variants: &Variants) -> impl Iterator<Item = TokenStream2> + '_ {
+    variants
+        .into_iter()
+        .map(|Variant { ident, fields, .. }| match fields {
+            Fields::Unnamed(FieldsUnnamed { unnamed, .. }) => {
+                let idx = (0..unnamed.iter().count())
+                    .into_iter()
+                    .map(|idx| format_ident!("_{}", idx))
+                    .collect::<Vec<_>>();
+                quote! {
+                    #ident(
+                        #(
+                            #idx,
+                        )*
+                    ) => {
+                        Self::RefData::#ident(
+                            #(
+                                #idx.into_ref_data(db),
+                            )*
+                        )
+                    }
+                }
+            }
+            Fields::Unit => quote!(#ident => Self::RefData::#ident),
+            Fields::Named(FieldsNamed { named, .. }) => {
+                let fields = named
+                    .into_iter()
+                    .map(|Field { ident, .. }| ident.as_ref().unwrap())
+                    .collect::<Vec<_>>();
+                quote! {
+                    #ident {
+                        #(
+                            #fields,
+                        )*
+                    } => {
+                        Self::RefData::#ident {
+                            #(
+                                #fields: #fields.into_ref_data(db)
+                            )*
+                        }
+                    }
+                }
+            }
+        })
 }
 
 pub(super) fn gen(item: TokenStream) -> TokenStream {
-    // Generated code depends on the `salsa` and `tydi_intern` crates.
-    let salsa = format_ident!("salsa");
-    let tydi_intern = format_ident!("tydi_intern");
-
     // Keep copy of original input.
     let input: TokenStream2 = item.clone().into();
 
@@ -96,14 +152,8 @@ pub(super) fn gen(item: TokenStream) -> TokenStream {
             .expect("can't be used on an empty mod")
             .1
             .into_iter()
-            // Skip over everything that is not a struct (todo(mb) or enum)
-            .filter(|item| matches!(item, Item::Struct(_)))
-            .map(|item| match item {
-                Item::Struct(ItemStruct { ident, fields, .. }) => {
-                    InternItem::Struct { ident, fields }
-                }
-                _ => unreachable!(),
-            });
+            // Skip over everything that is not a struct or enum
+            .filter(|item| matches!(item, Item::Struct(_) | Item::Enum(_)));
 
         // Generate the intern trait.
         let title_case = ident.to_string().to_title_case();
@@ -111,63 +161,103 @@ pub(super) fn gen(item: TokenStream) -> TokenStream {
         let intern_storage = format_ident!("Intern{}Database", title_case);
         let intern_id = items
             .clone()
-            .map(|item| item.intern_id())
+            .map(|item| intern_id_ident(item_ident(&item)))
             .collect::<Vec<_>>();
         let intern_ref_data = items
             .clone()
-            .map(|item| item.ref_data())
+            .map(|item| ref_data_ident(item_ident(&item)))
             .collect::<Vec<_>>();
-        let intern_fn = items.clone().map(|item| item.intern_fn());
+        let intern_fn = items.clone().map(|item| intern_fn_ident(item_ident(&item)));
         tokens.extend(quote!(
             #[automatically_derived]
-            #[#salsa::query_group(#intern_storage)]
-            pub trait #intern_trait: #tydi_intern::InternSupport {
+            #[::salsa::query_group(#intern_storage)]
+            pub trait #intern_trait: ::tydi_intern::InternSupport {
                 #(
-                    #[#salsa::interned]
+                    #[::salsa::interned]
                     fn #intern_fn(&self, data: #intern_ref_data) -> #intern_id;
                 )*
             }
         ));
 
-        // Generate id and ref data structures.
+        // Generate Id struct.
         tokens.extend(items.clone().map(|item| {
-            let ident = item.ident();
-            let id = item.intern_id();
-            let ref_data = item.ref_data();
-            let field_ident = item.field_ident().collect::<Vec<_>>();
-            let field_index = item.field_index();
-            let field_types = item.field_types();
+            let ident = item_ident(&item);
+            let id = intern_id_ident(ident);
 
-            // Generate the id and ref data structures and impl ToRefData.
             quote!(
                 #[automatically_derived]
-                #tydi_intern::intern_id!(#ident, #id);
-
-                #[automatically_derived]
-                #[derive(Clone, Debug, Hash, PartialEq, Eq)]
-                pub struct #ref_data {
-                    #(
-                        pub #field_ident: <#field_types as #tydi_intern::IntoRefData>::RefData,
-                    )*
-                }
-
-                #[automatically_derived]
-                impl #tydi_intern::IntoRefData for #ident {
-                    type Id = #id;
-                    type RefData = #ref_data;
-                    fn into_ref_data(self, db: &dyn #tydi_intern::InternSupport) -> Self::RefData {
-                        #(
-                            let #field_ident = self.#field_index.into_ref_data(db);
-                        )*
-                        Self::RefData {
-                            #(
-                                #field_ident,
-                            )*
-                        }
-                    }
-                }
+                ::tydi_intern::intern_id!(#ident, #id);
             )
         }));
+
+        // Generate RefData struct and IntoRefData impl.
+        tokens.extend(items.clone().map(|item| {
+            match item {
+                Item::Struct(ItemStruct {  ident, fields, .. }) => {
+                    let id = intern_id_ident(&ident);
+                    let ref_data = ref_data_ident(&ident);
+                    let field_ident = fields_ident_iter(&fields).collect::<Vec<_>>();
+                    let field_index = fields_index_iter(&fields);
+                    let field_types = fields_types_iter(&fields);
+
+                    quote!(
+                        #[automatically_derived]
+                        #[derive(Clone, Debug, Hash, PartialEq, Eq)]
+                        pub struct #ref_data {
+                            #(
+                                pub #field_ident: <#field_types as ::tydi_intern::IntoRefData>::RefData,
+                            )*
+                        }
+
+                        #[automatically_derived]
+                        impl ::tydi_intern::IntoRefData for #ident {
+                            type Id = #id;
+                            type RefData = #ref_data;
+                            fn into_ref_data(self, db: &dyn ::tydi_intern::InternSupport) -> Self::RefData {
+                                #(
+                                    let #field_ident = self.#field_index.into_ref_data(db);
+                                )*
+                                Self::RefData {
+                                    #(
+                                        #field_ident,
+                                    )*
+                                }
+                            }
+                        }
+                    )
+                },
+                Item::Enum(ItemEnum { ident, variants, .. }) => {
+                    let id = intern_id_ident(&ident);
+                    let ref_data = ref_data_ident(&ident);
+                    let variant_ref_data = variant_ref_data_iter(&variants);
+                    let variant_into_ref_data = variant_into_ref_data_iter(&variants);
+
+                    quote!(
+                        #[automatically_derived]
+                        #[derive(Clone, Debug, Hash, PartialEq, Eq)]
+                        pub enum #ref_data {
+                            #(
+                                #variant_ref_data,
+                            )*
+                        }
+
+                        #[automatically_derived]
+                        impl ::tydi_intern::IntoRefData for #ident {
+                            type Id = #id;
+                            type RefData = #ref_data;
+                            fn into_ref_data(self, db: &dyn ::tydi_intern::InternSupport) -> Self::RefData {
+                                match self {
+                                    #(
+                                        Self::#variant_into_ref_data,
+                                    )*
+                                }
+                            }
+                        }
+                    )
+                }
+                _ => unreachable!()
+            }}));
+
         tokens = quote!(
             mod gen {
                 use super::*;


### PR DESCRIPTION
This makes it possible to use enums for ir types, and updates the ref data types for structs to better match the field types of the original type.