### PR TITLE
Add range information to the tokens produced by the Lexer

### DIFF
--- a/crates/lexer/Cargo.toml
+++ b/crates/lexer/Cargo.toml
@@ -7,3 +7,4 @@ description = "Lexer for Tydi"
 
 [dependencies]
 logos = "0.12"
+text-size = "1"

--- a/crates/lexer/src/lib.rs
+++ b/crates/lexer/src/lib.rs
@@ -6,13 +6,15 @@
 //!
 //! ```rust
 //! use tydi_lexer::{Lexer, Token, TokenKind};
+//! use text_size::{TextRange, TextSize};
 //!
 //! let input = "type Byte = Bits<8>;";
 //! let mut lexer = Lexer::new(input);
 //!
-//! let Token { kind, text } = lexer.next().unwrap();
+//! let Token { kind, text, range } = lexer.next().unwrap();
 //! assert_eq!(kind, TokenKind::Type);
 //! assert_eq!(text, "type");
+//! assert_eq!(range.len(), TextSize::from(4));
 //!
 //! let token = lexer.next().unwrap();
 //! assert!(token.is_trivia());

--- a/crates/lexer/src/lib.rs
+++ b/crates/lexer/src/lib.rs
@@ -30,6 +30,8 @@
 //! ```
 
 use logos::Logos;
+use std::{convert::TryInto, ops::Range};
+use text_size::TextRange;
 
 /// Tokens, the primitive productions used in the grammar rules.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Logos)]
@@ -106,7 +108,9 @@ impl<'src> Iterator for Lexer<'src> {
     fn next(&mut self) -> Option<Self::Item> {
         let kind = self.0.next()?;
         let text = self.0.slice();
-        Some(Token { kind, text })
+        let Range { start, end } = self.0.span();
+        let range = TextRange::new(start.try_into().unwrap(), end.try_into().unwrap());
+        Some(Token { kind, text, range })
     }
 }
 
@@ -115,6 +119,7 @@ impl<'src> Iterator for Lexer<'src> {
 pub struct Token<'src> {
     pub kind: TokenKind,
     pub text: &'src str,
+    pub range: TextRange,
 }
 
 impl Token<'_> {


### PR DESCRIPTION
We need this data later to add span information to errors. The `text-size` is also used by `rowan` (`syntax` crate).

bors r+